### PR TITLE
Use typedef to hide actual IntoIterator implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,10 +248,11 @@ impl<T> SuccinctVec<T> {
 }
 
 type VecIter<T> = std::vec::IntoIter<T>;
+pub type SuccinctIter<T> = std::iter::FlatMap<VecIter<Vec<T>>, VecIter<T>, fn(Vec<T>) -> VecIter<T>>;
 
 impl<T> IntoIterator for SuccinctVec<T> {
     type Item = T;
-    type IntoIter = std::iter::FlatMap<VecIter<Vec<T>>, VecIter<T>, fn(Vec<T>) -> VecIter<T>>;
+    type IntoIter = SuccinctIter<T>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.data_blocks.into_iter().flat_map(IntoIterator::into_iter)


### PR DESCRIPTION
Since we cannot use `impl Trait` in traits yet a typedef will have to suffice. Newtyping this would be an alternative that would be safer, but would incur a maintenance & semver burden. This is currently not a breaking change due to the way Rusts typedefs work.